### PR TITLE
Added vout index when rpc sync kicks in

### DIFF
--- a/syncer/gateways.py
+++ b/syncer/gateways.py
@@ -54,14 +54,14 @@ class MongoDatabaseGateway(object):
         self.transactions.create_index([("vout.addresses", pymongo.DESCENDING)])
         self.transactions.create_index([("vin.prev_txid", pymongo.DESCENDING)])
 
-    def flush_cache(self, is_rpc=None):
+    def flush_cache(self):
         if self.block_cache:
             self.blocks.insert_many(
                 [BlockSerializer.to_database(block) for block in self.block_cache.values()])
 
         if self.tr_cache:
             self.transactions.insert_many(
-                [TransactionSerializer.to_database(tr, is_rpc) for tr in self.tr_cache.values()])
+                [TransactionSerializer.to_database(tr) for tr in self.tr_cache.values()])
 
         self.block_cache = {}
         self.tr_cache = {}
@@ -289,7 +289,7 @@ class MongoDatabaseGateway(object):
         # This is used for development purposes beacuse we don't want to wait a whole day to test this
         one_hour = 3600
         two_minutes = 120
-        
+
         # We use these three minutes to create a time lapse where we want to look for old prices
         # Three minutes are used because we insert new price every 5 minutes
         three_minutes = 240

--- a/syncer/interactors.py
+++ b/syncer/interactors.py
@@ -315,7 +315,7 @@ class BlockchainSyncer(object):
             block = BlockFactory.from_rpc(rpc_block, rpc_block_transactions)
             self.blockchain.insert_block(block)
 
-        self.db.flush_cache(True)
+        self.db.flush_cache()
         end_time = datetime.datetime.now()
         diff_time = end_time - start_time
         logging.info("[SYNC_RPC_COMPLETE] %s, duration: %s seconds" % (end_time, diff_time.total_seconds()))

--- a/syncer/serializers.py
+++ b/syncer/serializers.py
@@ -1,5 +1,3 @@
-import logging
-
 class VoutSerializer(object):
     @staticmethod
     def to_database(vout):
@@ -49,7 +47,6 @@ class TransactionSerializer(object):
                 formatted['vout'].append(VoutSerializer.to_database(v))
             elif v.index:
                 formatted['vout'].append(VoutSerializer.to_database(v))
-                logging.info("nesto")
 
         return formatted
 

--- a/syncer/serializers.py
+++ b/syncer/serializers.py
@@ -13,17 +13,6 @@ class VoutSerializer(object):
             "spent": vout.spent
         }
 
-    @staticmethod
-    def to_database_rpc(vout_rpc):
-        return {
-            "value": vout_rpc.value,
-            "asm": vout_rpc.asm,
-            "addresses": vout_rpc.addresses,
-            "type": vout_rpc.type,
-            "reqSigs": vout_rpc.reqSigs,
-            "spent": vout_rpc.spent
-        }
-
 class VinSerializer(object):
     @staticmethod
     def to_database(vin):
@@ -38,7 +27,7 @@ class VinSerializer(object):
 
 class TransactionSerializer(object):
     @staticmethod
-    def to_database(tr, is_rpc=None):
+    def to_database(tr):
         formatted = {
             "version": tr.version,
             "locktime": tr.locktime,
@@ -54,19 +43,17 @@ class TransactionSerializer(object):
         for v in tr.vin:
             formatted['vin'].append(VinSerializer.to_database(v))
 
-        if not is_rpc:
-            for v in tr.vout:
+        for index, v in enumerate(tr.vout):
+            if v.index is None:
+                v.index = index
                 formatted['vout'].append(VoutSerializer.to_database(v))
+            elif v.index:
+                formatted['vout'].append(VoutSerializer.to_database(v))
+                logging.info("nesto")
 
-            return formatted
-        else:
-            for v in tr.vout:
-                formatted['vout'].append(VoutSerializer.to_database_rpc(v))
+        return formatted
 
 
-            return formatted
-
-        
 class BlockSerializer(object):
     @staticmethod
     def to_database(block):


### PR DESCRIPTION
Vout index was missing when rpc sync took over.
Reason: with rpc command getrawtransaction, vout index is named n, instead of index.
This was causing vout index field to be null when rpc sync starts.